### PR TITLE
Enhance duplicate cleaner UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ Run the application with:
 ```
 python -m duplicate_file_cleaner.webapp
 ```
-
-Enter the directory to scan, review the duplicates found, and confirm deletion.
-The tool keeps the oldest copy of each duplicate set and logs removals to
-`duplicate_cleaner.log` while reporting the freed disk space.
+Enter the directory to scan or select **Scan entire system**. You can limit the
+search to specific file types such as images, videos, PDF or Word documents and
+navigate the folder hierarchy using the built‑in browser. Review the duplicates
+found and confirm deletion. The tool keeps the oldest copy of each duplicate set
+and logs removals to `duplicate_cleaner.log` while reporting the freed disk
+space.

--- a/tests/test_duplicates.py
+++ b/tests/test_duplicates.py
@@ -22,6 +22,16 @@ def test_find_duplicates(tmp_path):
     assert group == {"a.txt", "b.txt"}
 
 
+def test_find_duplicates_extensions(tmp_path):
+    (tmp_path / "a.jpg").write_text("img")
+    (tmp_path / "b.jpg").write_text("img")
+    (tmp_path / "c.txt").write_text("other")
+    dups = find_duplicates(str(tmp_path), extensions=[".jpg"])
+    assert len(dups) == 1
+    names = {p.name for p in dups[0]}
+    assert names == {"a.jpg", "b.jpg"}
+
+
 def test_delete_files(tmp_path):
     f1 = tmp_path / "a.txt"
     f1.write_text("hello")


### PR DESCRIPTION
## Summary
- add ability to filter duplicate search by file extension
- allow scanning the entire filesystem via checkbox
- provide simple directory browser in the web UI
- update README documentation
- test new extension filter behaviour

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68427a58bde48331bb7d0488fe3d0384