### PR TITLE
Add advanced duplicate cleaner features

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,11 @@ navigate the folder hierarchy using the built‑in browser. Review the duplicate
 found and confirm deletion. The tool keeps the oldest copy of each duplicate set
 and logs removals to `duplicate_cleaner.log` while reporting the freed disk
 space.
+
+### New Features
+
+* Browsing directories now supports pagination to avoid overly long lists.
+* You can limit the number of directories scanned per phase and estimate scan
+  time before running a full search.
+* Deletion history is stored in a local SQLite database located in your home
+  directory and can be viewed from the application's main page.

--- a/duplicate_file_cleaner/utils.py
+++ b/duplicate_file_cleaner/utils.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import hashlib
 import os
 from pathlib import Path
-from typing import Dict, List, Tuple, Iterable
+from typing import Dict, List, Tuple, Iterable, Optional
+
+import sqlite3
+from datetime import datetime
 
 
 def _file_hash(path: Path, chunk_size: int = 8192) -> str:
@@ -17,7 +20,14 @@ def _file_hash(path: Path, chunk_size: int = 8192) -> str:
     return hasher.hexdigest()
 
 
-def find_duplicates(directory: str, extensions: Iterable[str] | None = None) -> List[List[Path]]:
+HISTORY_DB = Path.home() / ".duplicate_cleaner_history.db"
+
+
+def find_duplicates(
+    directory: str,
+    extensions: Iterable[str] | None = None,
+    max_dirs: Optional[int] = None,
+) -> List[List[Path]]:
     """Find exact duplicate files under *directory*.
 
     Parameters
@@ -26,6 +36,9 @@ def find_duplicates(directory: str, extensions: Iterable[str] | None = None) -> 
         Directory to search for duplicates.
     extensions: Iterable[str] | None
         Optional collection of file extensions to include (case-insensitive).
+    max_dirs: int | None
+        Optional limit on the number of directories to walk. This allows
+        scanning in phases and prevents long blocking operations.
 
     Returns
     -------
@@ -37,7 +50,9 @@ def find_duplicates(directory: str, extensions: Iterable[str] | None = None) -> 
     if extensions is not None:
         allowed = {e.lower() if e.startswith('.') else f'.{e.lower()}' for e in extensions}
     hashes: Dict[Tuple[int, str], List[Path]] = {}
-    for root, _, files in os.walk(base):
+    for idx, (root, _, files) in enumerate(os.walk(base)):
+        if max_dirs is not None and idx >= max_dirs:
+            break
         for name in files:
             path = Path(root) / name
             if allowed is not None and path.suffix.lower() not in allowed:
@@ -63,13 +78,49 @@ def delete_files(files: List[Path], log_file: Path) -> int:
     Returns total bytes freed.
     """
     freed = 0
+    deleted: List[str] = []
     with log_file.open("a") as log:
         for f in files:
             try:
                 size = f.stat().st_size
                 f.unlink()
                 freed += size
+                deleted.append(str(f))
                 log.write(f"Deleted {f}\n")
             except FileNotFoundError:
                 log.write(f"Missing {f}\n")
+    if deleted:
+        _record_history(deleted, freed, HISTORY_DB)
     return freed
+
+
+def _record_history(files: List[str], freed: int, db_path: Path = HISTORY_DB) -> None:
+    """Record deletion history in an SQLite database."""
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS history (id INTEGER PRIMARY KEY AUTOINCREMENT, timestamp TEXT, paths TEXT, bytes_freed INTEGER)"
+    )
+    ts = datetime.utcnow().isoformat()
+    conn.execute(
+        "INSERT INTO history (timestamp, paths, bytes_freed) VALUES (?, ?, ?)",
+        (ts, "\n".join(files), freed),
+    )
+    conn.commit()
+    conn.close()
+
+
+def get_history(limit: int | None = None, db_path: Path = HISTORY_DB) -> List[tuple[str, str, int]]:
+    """Return cleanup history from the SQLite database."""
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS history (id INTEGER PRIMARY KEY AUTOINCREMENT, timestamp TEXT, paths TEXT, bytes_freed INTEGER)"
+    )
+    cur = conn.cursor()
+    query = "SELECT timestamp, paths, bytes_freed FROM history ORDER BY id DESC"
+    if limit is not None:
+        cur.execute(query + " LIMIT ?", (limit,))
+    else:
+        cur.execute(query)
+    rows = cur.fetchall()
+    conn.close()
+    return rows

--- a/duplicate_file_cleaner/webapp.py
+++ b/duplicate_file_cleaner/webapp.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 
 import json
 import os
+import time
 from pathlib import Path
 from typing import Iterable, List
 
 from flask import Flask, render_template_string, request, url_for
 
-from .utils import delete_files, find_duplicates
+from .utils import delete_files, find_duplicates, get_history
 
 app = Flask(__name__)
 LOG_FILE = Path("duplicate_cleaner.log")
@@ -38,9 +39,12 @@ INDEX_HTML = """
       <option value="word">Word</option>
     </select>
   </label><br>
+  <label>Directories per phase: <input type="number" name="max_dirs" value="0"></label><br>
   <input type="submit" value="Scan">
+  <input type="submit" formaction="{{ url_for('estimate') }}" value="Estimate Time">
 </form>
 <p><a href="{{ url_for('browse') }}">Browse directories</a></p>
+<p><a href="{{ url_for('history') }}">View cleanup history</a></p>
 """
 
 RESULT_HTML = """
@@ -80,6 +84,23 @@ DELETE_HTML = """
 <a href="{{ url_for('index') }}">Back</a>
 """
 
+HISTORY_HTML = """
+<!doctype html>
+<title>History</title>
+<h1>Cleanup History</h1>
+<table border="1" cellpadding="5">
+  <tr><th>Timestamp</th><th>Files</th><th>Bytes Freed</th></tr>
+  {% for ts, paths, freed in rows %}
+  <tr>
+    <td>{{ ts }}</td>
+    <td><pre>{{ paths }}</pre></td>
+    <td>{{ freed }}</td>
+  </tr>
+  {% endfor %}
+</table>
+<a href="{{ url_for('index') }}">Back</a>
+"""
+
 BROWSE_HTML = """
 <!doctype html>
 <title>Browse</title>
@@ -92,6 +113,14 @@ BROWSE_HTML = """
   <li><a href="{{ url_for('browse', path=d) }}">{{ d }}</a></li>
   {% endfor %}
 </ul>
+<p>
+  {% if prev_offset is not none %}
+    <a href="{{ url_for('browse', path=current, offset=prev_offset) }}">Prev</a>
+  {% endif %}
+  {% if next_offset is not none %}
+    <a href="{{ url_for('browse', path=current, offset=next_offset) }}">Next</a>
+  {% endif %}
+</p>
 <p><a href="{{ url_for('index', path=current) }}">Select this directory</a></p>
 """
 
@@ -105,13 +134,26 @@ def index():
 @app.route("/browse")
 def browse():
     path = request.args.get("path", Path.home())
+    offset = int(request.args.get("offset", 0))
     p = Path(path)
     try:
         dirs = [str(d) for d in p.iterdir() if d.is_dir()]
     except PermissionError:
         dirs = []
+    dirs.sort()
+    limit = 20
+    page_dirs = dirs[offset : offset + limit]
+    next_offset = offset + limit if offset + limit < len(dirs) else None
+    prev_offset = offset - limit if offset - limit >= 0 else None
     parent = str(p.parent) if p != p.parent else None
-    return render_template_string(BROWSE_HTML, dirs=dirs, parent=parent, current=str(p))
+    return render_template_string(
+        BROWSE_HTML,
+        dirs=page_dirs,
+        parent=parent,
+        current=str(p),
+        next_offset=next_offset,
+        prev_offset=prev_offset,
+    )
 
 
 @app.route("/scan", methods=["POST"])
@@ -122,12 +164,44 @@ def scan():
             directory = os.environ.get("SystemDrive", "C:\\")
         else:
             directory = "/"
+    if os.name == "nt" and len(directory) == 2 and directory[1] == ":":
+        directory += "\\"
     ftype = request.form.get("type", "all")
     extensions = TYPE_MAP.get(ftype)
-    duplicates = find_duplicates(directory, extensions)
+    max_dirs = request.form.get("max_dirs")
+    try:
+        limit = int(max_dirs) if max_dirs else None
+    except ValueError:
+        limit = None
+    duplicates = find_duplicates(directory, extensions, max_dirs=limit if limit and limit > 0 else None)
     data = json.dumps([[str(p) for p in g] for g in duplicates])
     space = sum(sum(p.stat().st_size for p in g[1:]) for g in duplicates)
     return render_template_string(RESULT_HTML, duplicates=duplicates, space=space, data=data)
+
+
+@app.route("/estimate", methods=["POST"])
+def estimate():
+    directory = request.form.get("directory", "")
+    if request.form.get("entire"):
+        if os.name == "nt":
+            directory = os.environ.get("SystemDrive", "C:\\")
+        else:
+            directory = "/"
+    if os.name == "nt" and len(directory) == 2 and directory[1] == ":":
+        directory += "\\"
+    ftype = request.form.get("type", "all")
+    extensions = TYPE_MAP.get(ftype)
+    start = time.time()
+    count = 0
+    for root, _, files in os.walk(directory):
+        if time.time() - start > 180:
+            break
+        for name in files:
+            if extensions is not None and Path(name).suffix.lower() not in extensions:
+                continue
+            count += 1
+    seconds = int(count * 0.002)
+    return f"Estimated time: {seconds}s for {count} files"
 
 
 @app.route("/delete", methods=["POST"])
@@ -143,6 +217,12 @@ def delete():
                 freed += delete_files([p], LOG_FILE)
                 deleted.append(str(p))
     return render_template_string(DELETE_HTML, deleted=deleted, freed=freed)
+
+
+@app.route("/history")
+def history():
+    rows = get_history()
+    return render_template_string(HISTORY_HTML, rows=rows)
 
 
 if __name__ == "__main__":

--- a/tests/test_duplicates.py
+++ b/tests/test_duplicates.py
@@ -4,7 +4,8 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-from duplicate_file_cleaner.utils import find_duplicates, delete_files
+from duplicate_file_cleaner import utils
+from duplicate_file_cleaner.utils import find_duplicates, delete_files, get_history
 
 
 def test_find_duplicates(tmp_path):
@@ -20,6 +21,17 @@ def test_find_duplicates(tmp_path):
     assert len(dups) == 1
     group = {p.name for p in dups[0]}
     assert group == {"a.txt", "b.txt"}
+
+
+def test_find_duplicates_limit(tmp_path):
+    (tmp_path / "a.txt").write_text("one")
+    (tmp_path / "dir1").mkdir()
+    (tmp_path / "dir1" / "b.txt").write_text("one")
+    (tmp_path / "dir2").mkdir()
+    (tmp_path / "dir2" / "c.txt").write_text("one")
+    dups = find_duplicates(str(tmp_path), max_dirs=1)
+    # Only root directory scanned so duplicates should be empty
+    assert dups == []
 
 
 def test_find_duplicates_extensions(tmp_path):
@@ -40,3 +52,15 @@ def test_delete_files(tmp_path):
     assert freed == len("hello")
     assert not f1.exists()
     assert "Deleted" in log.read_text()
+
+
+def test_delete_files_history(tmp_path, monkeypatch):
+    db = tmp_path / "history.db"
+    monkeypatch.setattr(utils, "HISTORY_DB", db)
+    f1 = tmp_path / "x.txt"
+    f1.write_text("hi")
+    log = tmp_path / "log.txt"
+    delete_files([f1], log)
+    history = get_history(db_path=db)
+    assert history
+    assert "x.txt" in history[-1][1]


### PR DESCRIPTION
## Summary
- paginate directory browsing
- allow phased scanning and provide estimated time
- keep deletion history in SQLite db and display it
- document new features in README
- test new utils functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68428269149c8331921fd04a67ac5018